### PR TITLE
Popup UX rework: regrouped stats, inline copy buttons, compact controls, milestones

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -33,6 +33,20 @@
     "message": "$PCT$% through $YEAR$",
     "placeholders": { "pct": { "content": "$1" }, "year": { "content": "$2" } }
   },
+  "milestonesLabel": { "message": "Milestones" },
+  "addMilestone": { "message": "Add milestone" },
+  "milestoneNamePlaceholder": { "message": "e.g. Launch" },
+  "milestoneAdd": { "message": "Add" },
+  "milestoneDaysLeft": {
+    "message": "$COUNT$ left",
+    "placeholders": { "count": { "content": "$1" } }
+  },
+  "milestoneToday": { "message": "Today 🎉" },
+  "milestonePassed": {
+    "message": "$COUNT$ ago",
+    "placeholders": { "count": { "content": "$1" } }
+  },
+  "removeMilestone": { "message": "Remove milestone" },
   "optionsTitle": { "message": "Settings" },
   "themeLabel": { "message": "Theme" },
   "themeLight": { "message": "Light" },

--- a/popup/popup.css
+++ b/popup/popup.css
@@ -105,15 +105,28 @@ body {
 /* ── Hero ─────────────────────────────────────────────────────────────── */
 .hero {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
   gap: var(--gap);
 }
 
 .hero-week {
   display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.hero-week-top {
+  display: flex;
   align-items: baseline;
   gap: 8px;
+}
+
+/* "N days left in week" sits with the week number it belongs to. */
+.hero-sub {
+  font-size: 0.72rem;
+  color: var(--muted);
+  font-variant-numeric: tabular-nums;
 }
 
 .hero-kicker {
@@ -141,10 +154,82 @@ body {
   font-weight: 600;
 }
 
+.hero-date-row {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 4px;
+  margin-top: 2px;
+}
+
 .hero-date {
   font-size: 0.82rem;
   color: var(--muted);
-  margin-top: 2px;
+}
+
+/* Small inline copy button — lives next to the value it copies. */
+.copy-btn {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  opacity: 0.55;
+  transition:
+    opacity 0.15s ease,
+    color 0.15s ease,
+    background 0.15s ease;
+}
+
+.copy-btn svg {
+  width: 14px;
+  height: 14px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.copy-btn:hover {
+  opacity: 1;
+  color: var(--accent);
+  background: var(--surface-2);
+}
+
+.copy-btn.copied {
+  opacity: 1;
+  color: #2e9e5b;
+}
+
+/* "Copied!" confirmation tooltip above the button. */
+.copy-btn.copied::after {
+  content: attr(data-copied);
+  position: absolute;
+  bottom: 124%;
+  left: 50%;
+  transform: translateX(-50%);
+  background: #2e9e5b;
+  color: #fff;
+  font-size: 0.62rem;
+  font-weight: 600;
+  padding: 2px 7px;
+  border-radius: 5px;
+  white-space: nowrap;
+  pointer-events: none;
+  z-index: 1;
+}
+
+/* The hero-week copy button aligns to the big number's baseline. */
+.hero-week-top .copy-btn {
+  align-self: center;
 }
 
 /* ── Day strip ────────────────────────────────────────────────────────── */
@@ -237,35 +322,42 @@ body {
   transform: scaleY(1.5);
 }
 
+/* Year stats under the strip: days left (left) + % elapsed (right). */
+.year-meta {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.year-days-left,
 .year-progress {
   font-size: 0.72rem;
   color: var(--muted);
-  text-align: right;
   font-variant-numeric: tabular-nums;
 }
 
-/* ── Controls ─────────────────────────────────────────────────────────── */
+/* ── Controls: everything on a single row ─────────────────────────────── */
 .controls {
   display: flex;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
   align-items: flex-end;
-  gap: 10px;
+  gap: 8px;
 }
 
 .control {
   display: flex;
   flex-direction: column;
   gap: 4px;
-  flex: 1 1 120px;
+}
+
+.control--date {
+  flex: 1 1 auto;
+  min-width: 0;
 }
 
 .control--narrow {
   flex: 0 0 auto;
-}
-
-.control--auto {
-  flex: 0 0 auto;
-  justify-content: flex-end;
 }
 
 .control label {
@@ -276,14 +368,11 @@ body {
   color: var(--muted);
 }
 
-.control-spacer {
-  height: 0.68rem;
-}
-
 input[type="date"],
 input[type="number"] {
   font: inherit;
-  padding: 7px 9px;
+  font-size: 0.85rem;
+  padding: 8px 8px;
   border: 1px solid var(--border);
   border-radius: var(--radius-sm);
   background: var(--surface-2);
@@ -292,8 +381,12 @@ input[type="number"] {
   transition: border-color 0.2s ease;
 }
 
+input[type="date"] {
+  width: 100%;
+}
+
 input[type="number"] {
-  width: 64px;
+  width: 52px;
   text-align: center;
 }
 
@@ -302,14 +395,35 @@ input[type="number"]:focus {
   border-color: var(--accent);
 }
 
+/* Round swatch instead of the boxy native color well. */
 input[type="color"] {
-  width: 40px;
-  height: 36px;
-  padding: 2px;
+  appearance: none;
+  -webkit-appearance: none;
+  flex: 0 0 auto;
+  width: 34px;
+  height: 34px;
+  padding: 0;
   border: 1px solid var(--border);
-  border-radius: var(--radius-sm);
+  border-radius: 50%;
   background: var(--surface-2);
   cursor: pointer;
+  transition:
+    border-color 0.2s ease,
+    transform 0.12s ease;
+}
+
+input[type="color"]:hover {
+  border-color: var(--accent);
+  transform: translateY(-1px);
+}
+
+input[type="color"]::-webkit-color-swatch-wrapper {
+  padding: 4px;
+}
+
+input[type="color"]::-webkit-color-swatch {
+  border: none;
+  border-radius: 50%;
 }
 
 /* ── Buttons ──────────────────────────────────────────────────────────── */
@@ -348,67 +462,19 @@ input[type="color"] {
   background: transparent;
 }
 
-.btn.copied {
-  background: #2e9e5b;
-  color: #fff;
-  border-color: #2e9e5b;
-}
-
-/* ── Footer: info chips (left) + copy actions (right), one tidy row ──────── */
-.footer {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 10px;
-  border-top: 1px solid var(--border);
-  padding-top: 12px;
-}
-
-.stats {
-  display: flex;
-  gap: 6px;
-  flex-wrap: wrap;
-  min-width: 0;
-}
-
-.chip {
-  font-size: 0.72rem;
-  font-weight: 500;
-  color: var(--muted);
-  background: var(--surface-2);
-  border: 1px solid var(--border);
-  border-radius: 999px;
-  padding: 3px 9px;
-  white-space: nowrap;
-}
-
-.actions {
-  display: flex;
-  gap: 6px;
-  flex: 0 0 auto;
-}
-
-.icon-btn {
-  position: relative;
+/* Round icon-only button (the ↺ Today jump). */
+.btn--icon {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 32px;
-  height: 32px;
+  flex: 0 0 auto;
+  width: 34px;
+  height: 34px;
   padding: 0;
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  background: var(--surface-2);
-  color: var(--muted);
-  cursor: pointer;
-  transition:
-    background 0.15s ease,
-    color 0.15s ease,
-    border-color 0.15s ease,
-    transform 0.1s ease;
+  border-radius: 50%;
 }
 
-.icon-btn svg {
+.btn--icon svg {
   width: 17px;
   height: 17px;
   fill: none;
@@ -418,32 +484,159 @@ input[type="color"] {
   stroke-linejoin: round;
 }
 
-.icon-btn:hover {
-  color: var(--accent);
-  border-color: var(--accent);
-  transform: translateY(-1px);
+.btn--sm {
+  font-size: 0.76rem;
+  padding: 6px 10px;
 }
 
-.icon-btn.copied {
-  color: #2e9e5b;
+.btn.copied {
+  background: #2e9e5b;
+  color: #fff;
   border-color: #2e9e5b;
 }
 
-/* "Copied!" confirmation tooltip above the button. */
-.icon-btn.copied::after {
-  content: attr(data-copied);
-  position: absolute;
-  bottom: 124%;
-  left: 50%;
-  transform: translateX(-50%);
-  background: #2e9e5b;
-  color: #fff;
-  font-size: 0.62rem;
+/* ── Milestones: user countdowns (name + date → days left) ────────────── */
+.milestones {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  border-top: 1px solid var(--border);
+  padding-top: 10px;
+}
+
+.milestones-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.section-label {
+  font-size: 0.68rem;
   font-weight: 600;
-  padding: 2px 7px;
-  border-radius: 5px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.milestone-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.milestone-list:empty {
+  display: none;
+}
+
+.milestone {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 9px;
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+}
+
+.ms-name {
+  flex: 1;
+  min-width: 0;
+  font-size: 0.8rem;
+  font-weight: 600;
   white-space: nowrap;
-  pointer-events: none;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.ms-date {
+  font-size: 0.7rem;
+  color: var(--muted);
+  white-space: nowrap;
+}
+
+.ms-days {
+  font-size: 0.72rem;
+  font-weight: 700;
+  color: var(--accent);
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+}
+
+.ms-days.is-today {
+  color: #2e9e5b;
+}
+
+.ms-days.is-past {
+  color: var(--muted);
+  font-weight: 500;
+}
+
+.ms-del {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  padding: 0;
+  border: none;
+  border-radius: 5px;
+  background: transparent;
+  color: var(--muted);
+  font-size: 0.85rem;
+  line-height: 1;
+  cursor: pointer;
+  opacity: 0.5;
+  transition:
+    opacity 0.15s ease,
+    color 0.15s ease,
+    background 0.15s ease;
+}
+
+.milestone:hover .ms-del,
+.ms-del:focus-visible {
+  opacity: 1;
+}
+
+.ms-del:hover {
+  color: #d64545;
+  background: var(--surface);
+}
+
+.milestone-form {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.milestone-form[hidden] {
+  display: none;
+}
+
+.milestone-form input[type="text"] {
+  flex: 1;
+  min-width: 0;
+  font: inherit;
+  font-size: 0.8rem;
+  padding: 6px 8px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--surface-2);
+  color: var(--text);
+  outline: none;
+  transition: border-color 0.2s ease;
+}
+
+.milestone-form input[type="text"]:focus {
+  border-color: var(--accent);
+}
+
+.milestone-form input[type="date"] {
+  font-size: 0.78rem;
+  padding: 6px;
+  width: 116px;
 }
 
 /* ── Change highlight ─────────────────────────────────────────────────── */

--- a/popup/popup.html
+++ b/popup/popup.html
@@ -7,15 +7,46 @@
   </head>
   <body>
     <main class="card">
-      <!-- Hero: big week number + the focused date/day -->
+      <!-- Hero: big week number (+ days left in week, copy) | day + date (copy) -->
       <header class="hero">
         <div class="hero-week">
-          <span class="hero-kicker" data-i18n="labelWeek">Week</span>
-          <span id="weekNumberDisplay" class="hero-number">–</span>
+          <div class="hero-week-top">
+            <span class="hero-kicker" data-i18n="labelWeek">Week</span>
+            <span id="weekNumberDisplay" class="hero-number">–</span>
+            <button
+              type="button"
+              id="copyWeekBtn"
+              class="copy-btn"
+              data-i18n-title="copyWeek"
+              title="Copy week"
+              aria-label="Copy week"
+            >
+              <svg viewBox="0 0 24 24" aria-hidden="true">
+                <rect x="9" y="9" width="12" height="12" rx="2" />
+                <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+              </svg>
+            </button>
+          </div>
+          <div id="daysLeftWeek" class="hero-sub"></div>
         </div>
         <div class="hero-meta">
           <div id="dayDisplay" class="hero-day"></div>
-          <div id="dateDisplay" class="hero-date"></div>
+          <div class="hero-date-row">
+            <div id="dateDisplay" class="hero-date"></div>
+            <button
+              type="button"
+              id="copyDateBtn"
+              class="copy-btn"
+              data-i18n-title="copyDate"
+              title="Copy date"
+              aria-label="Copy date"
+            >
+              <svg viewBox="0 0 24 24" aria-hidden="true">
+                <rect x="9" y="9" width="12" height="12" rx="2" />
+                <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+              </svg>
+            </button>
+          </div>
         </div>
       </header>
 
@@ -30,15 +61,19 @@
         <div class="day" id="day7"></div>
       </section>
 
-      <!-- Year in weeks: one tick per week, current week glowing, click to jump -->
+      <!-- Year in weeks: one tick per week, current week glowing, click to jump.
+           Year stats (days left + % elapsed) live right under their strip. -->
       <section class="year-section" aria-label="Weeks of the year">
         <div id="yearStrip" class="year-strip"></div>
-        <div id="yearProgress" class="year-progress"></div>
+        <div class="year-meta">
+          <span id="daysLeftYear" class="year-days-left"></span>
+          <span id="yearProgress" class="year-progress"></span>
+        </div>
       </section>
 
-      <!-- Controls -->
+      <!-- Controls: date + week inputs, round Today + icon-color buttons, one row -->
       <section class="controls">
-        <div class="control">
+        <div class="control control--date">
           <label for="dateInput" data-i18n="labelDate">Date</label>
           <input type="date" id="dateInput" />
         </div>
@@ -46,52 +81,60 @@
           <label for="weekInput" data-i18n="labelWeek">Week</label>
           <input type="number" id="weekInput" min="1" max="53" placeholder="5" />
         </div>
-        <div class="control control--auto">
-          <span class="control-spacer"></span>
-          <button type="button" id="resetButton" class="btn btn--primary" data-i18n="labelToday">
-            Today
-          </button>
-        </div>
-        <div class="control control--narrow">
-          <label for="iconColor" data-i18n="labelIconColor">Icon color</label>
-          <input type="color" id="iconColor" value="#000000" />
-        </div>
+        <button
+          type="button"
+          id="resetButton"
+          class="btn btn--primary btn--icon"
+          data-i18n-title="labelToday"
+          title="Today"
+          aria-label="Today"
+        >
+          <svg viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M3 12a9 9 0 1 0 2.6-6.4M3 3v5.6h5.6" />
+            <circle cx="12" cy="12" r="1.6" fill="currentColor" stroke="none" />
+          </svg>
+        </button>
+        <input
+          type="color"
+          id="iconColor"
+          value="#000000"
+          data-i18n-title="labelIconColor"
+          title="Icon color"
+        />
       </section>
 
-      <!-- Footer: days remaining (info) + copy actions -->
-      <footer class="footer">
-        <div class="stats">
-          <span id="daysLeftWeek" class="chip"></span>
-          <span id="daysLeftYear" class="chip"></span>
-        </div>
-        <div class="actions">
+      <!-- Milestones: user-defined countdowns (name + date → days left) -->
+      <section class="milestones" aria-label="Milestones">
+        <div class="milestones-header">
+          <span class="section-label" data-i18n="milestonesLabel">Milestones</span>
           <button
             type="button"
-            id="copyWeekBtn"
-            class="icon-btn"
-            data-i18n-title="copyWeek"
-            title="Copy week"
-            aria-label="Copy week"
+            id="addMilestoneBtn"
+            class="copy-btn"
+            data-i18n-title="addMilestone"
+            title="Add milestone"
+            aria-label="Add milestone"
           >
             <svg viewBox="0 0 24 24" aria-hidden="true">
-              <path d="M5 9h14M5 15h14M9 4 7 20M17 4l-2 16" />
-            </svg>
-          </button>
-          <button
-            type="button"
-            id="copyDateBtn"
-            class="icon-btn"
-            data-i18n-title="copyDate"
-            title="Copy date"
-            aria-label="Copy date"
-          >
-            <svg viewBox="0 0 24 24" aria-hidden="true">
-              <rect x="3" y="5" width="18" height="16" rx="2" />
-              <path d="M3 9h18M8 3v4M16 3v4" />
+              <path d="M12 5v14M5 12h14" />
             </svg>
           </button>
         </div>
-      </footer>
+        <ul id="milestoneList" class="milestone-list"></ul>
+        <form id="milestoneForm" class="milestone-form" hidden>
+          <input
+            type="text"
+            id="milestoneName"
+            maxlength="30"
+            data-i18n-placeholder="milestoneNamePlaceholder"
+            placeholder="e.g. Launch"
+          />
+          <input type="date" id="milestoneDate" />
+          <button type="submit" class="btn btn--primary btn--sm" data-i18n="milestoneAdd">
+            Add
+          </button>
+        </form>
+      </section>
     </main>
 
     <script type="module" src="popup.js"></script>

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -8,6 +8,7 @@ import {
   sameYMD,
   daysLeftInWeek,
   daysLeftInYear,
+  daysUntil,
   yearFromDateValue,
   yearProgress,
 } from "../week.js";
@@ -34,6 +35,7 @@ document.addEventListener("DOMContentLoaded", function () {
   // Set from stored settings before the first render.
   let weekSystem = SETTINGS_DEFAULTS.weekSystem;
   let firstDayOfWeek = SETTINGS_DEFAULTS.firstDayOfWeek;
+  let milestones = SETTINGS_DEFAULTS.milestones;
 
   // The weekday a week starts on (centralized rule in week.js).
   const weekStartDay = () => resolveWeekStartDay(weekSystem, firstDayOfWeek);
@@ -68,6 +70,9 @@ document.addEventListener("DOMContentLoaded", function () {
     document.getElementById("weekInput").value = getWeekNumber(now, weekSystem, weekStartDay());
     updateDayName(now);
     displayWeekFromDate(now);
+
+    milestones = Array.isArray(s.milestones) ? s.milestones : [];
+    renderMilestones();
   });
 
   document.getElementById("resetButton").addEventListener("click", function () {
@@ -116,6 +121,97 @@ document.addEventListener("DOMContentLoaded", function () {
   document.getElementById("copyDateBtn").addEventListener("click", function () {
     copyText(document.getElementById("dateInput").value, this);
   });
+
+  // ── Milestones: add via the inline form, remove via ×, persisted in sync ──
+  const milestoneForm = document.getElementById("milestoneForm");
+
+  document.getElementById("addMilestoneBtn").addEventListener("click", function () {
+    milestoneForm.hidden = !milestoneForm.hidden;
+    if (!milestoneForm.hidden) {
+      const dateField = document.getElementById("milestoneDate");
+      if (!dateField.value) dateField.value = toLocalISODate(new Date());
+      document.getElementById("milestoneName").focus();
+    }
+  });
+
+  milestoneForm.addEventListener("submit", function (e) {
+    e.preventDefault();
+    const nameField = document.getElementById("milestoneName");
+    const name = nameField.value.trim();
+    const date = document.getElementById("milestoneDate").value;
+    if (!name || !date) return;
+    milestones.push({ name, date });
+    // Soonest first, so the next milestone is always on top.
+    milestones.sort((a, b) => (a.date < b.date ? -1 : 1));
+    saveSettings({ milestones });
+    nameField.value = "";
+    milestoneForm.hidden = true;
+    renderMilestones();
+  });
+
+  function removeMilestone(index) {
+    milestones.splice(index, 1);
+    saveSettings({ milestones });
+    renderMilestones();
+  }
+
+  // Countdown label: "12 days left" / "Today 🎉" / "3 days ago".
+  function milestoneCountdown(n) {
+    if (n === 0) return chrome.i18n.getMessage("milestoneToday") || "Today 🎉";
+    if (n < 0)
+      return (
+        chrome.i18n.getMessage("milestonePassed", [dayCountLabel(-n)]) || `${dayCountLabel(-n)} ago`
+      );
+    return (
+      chrome.i18n.getMessage("milestoneDaysLeft", [dayCountLabel(n)]) || `${dayCountLabel(n)} left`
+    );
+  }
+
+  function renderMilestones() {
+    const list = document.getElementById("milestoneList");
+    list.textContent = "";
+    const today = new Date();
+    const language = navigator.language || "en";
+
+    milestones.forEach(function (m, index) {
+      const target = new Date(m.date + "T00:00:00");
+      const left = daysUntil(target, today);
+
+      const item = document.createElement("li");
+      item.className = "milestone";
+
+      const name = document.createElement("span");
+      name.className = "ms-name";
+      name.textContent = m.name;
+      name.title = m.name;
+
+      const date = document.createElement("span");
+      date.className = "ms-date";
+      date.textContent = new Intl.DateTimeFormat(language, {
+        day: "numeric",
+        month: "short",
+        year: target.getFullYear() === today.getFullYear() ? undefined : "numeric",
+      }).format(target);
+
+      const days = document.createElement("span");
+      days.className = "ms-days";
+      days.classList.toggle("is-today", left === 0);
+      days.classList.toggle("is-past", left < 0);
+      days.textContent = milestoneCountdown(left);
+
+      const del = document.createElement("button");
+      del.type = "button";
+      del.className = "ms-del";
+      del.textContent = "×";
+      const removeLabel = chrome.i18n.getMessage("removeMilestone") || "Remove milestone";
+      del.title = removeLabel;
+      del.setAttribute("aria-label", removeLabel);
+      del.addEventListener("click", () => removeMilestone(index));
+
+      item.append(name, date, days, del);
+      list.appendChild(item);
+    });
+  }
 
   function displayWeekFromDate(date, updateWeekNumberDisplay = true) {
     const startOfWeek = getWeekStart(date, weekStartDay());

--- a/settings.js
+++ b/settings.js
@@ -11,6 +11,7 @@ export const SETTINGS_DEFAULTS = {
   weekSystem: "iso", // "iso" | "us"
   firstDayOfWeek: 1, // 0 = Sunday, 1 = Monday
   iconMode: "icon", // "icon" (drawn number) | "badge" (badge text)
+  milestones: [], // [{ name: string, date: "YYYY-MM-DD" }] — popup countdowns
 };
 
 // Read all settings, merged over the defaults. Promise-based so callers can

--- a/tests/popup.dom.test.js
+++ b/tests/popup.dom.test.js
@@ -12,6 +12,10 @@ const MSG = {
   dayOne: "1 day",
   dayMany: "$1 days",
   copied: "Copied!",
+  milestoneDaysLeft: "$1 left",
+  milestoneToday: "Today 🎉",
+  milestonePassed: "$1 ago",
+  removeMilestone: "Remove milestone",
 };
 const fmt = (s, subs) => (subs || []).reduce((a, v, i) => a.replace("$" + (i + 1), v), s);
 
@@ -35,7 +39,14 @@ function buildDom() {
     <span id="daysLeftWeek"></span>
     <span id="daysLeftYear"></span>
     <button id="copyWeekBtn">Copy week</button>
-    <button id="copyDateBtn">Copy date</button>`;
+    <button id="copyDateBtn">Copy date</button>
+    <button id="addMilestoneBtn"></button>
+    <ul id="milestoneList"></ul>
+    <form id="milestoneForm" hidden>
+      <input type="text" id="milestoneName" />
+      <input type="date" id="milestoneDate" />
+      <button type="submit"></button>
+    </form>`;
 }
 
 function stubChrome(store = {}) {
@@ -193,6 +204,55 @@ describe("popup integration", () => {
     expect(document.querySelector('#yearStrip .week-tick[data-week="7"]').classList).toContain(
       "is-current"
     );
+  });
+
+  test("adding a milestone renders a row with a days-left countdown and persists it", async () => {
+    const store = {};
+    stubChrome(store);
+    document.dispatchEvent(new Event("DOMContentLoaded"));
+    await flush();
+
+    // Open the inline form and submit a milestone 10 days out.
+    document.getElementById("addMilestoneBtn").click();
+    const form = document.getElementById("milestoneForm");
+    expect(form.hidden).toBe(false);
+
+    const target = new Date();
+    target.setDate(target.getDate() + 10);
+    const pad = (n) => String(n).padStart(2, "0");
+    document.getElementById("milestoneName").value = "Launch";
+    document.getElementById("milestoneDate").value =
+      `${target.getFullYear()}-${pad(target.getMonth() + 1)}-${pad(target.getDate())}`;
+    form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+    await flush();
+
+    const rows = document.querySelectorAll("#milestoneList .milestone");
+    expect(rows.length).toBe(1);
+    expect(rows[0].querySelector(".ms-name").textContent).toBe("Launch");
+    expect(rows[0].querySelector(".ms-days").textContent).toBe("10 days left");
+    expect(form.hidden).toBe(true);
+    expect(store.milestones).toEqual([{ name: "Launch", date: expect.any(String) }]);
+  });
+
+  test("stored milestones render on load and × removes them", async () => {
+    const today = new Date();
+    const pad = (n) => String(n).padStart(2, "0");
+    const iso = `${today.getFullYear()}-${pad(today.getMonth() + 1)}-${pad(today.getDate())}`;
+    const store = { milestones: [{ name: "Demo day", date: iso }] };
+    stubChrome(store);
+    document.dispatchEvent(new Event("DOMContentLoaded"));
+    await flush();
+
+    // A milestone dated today shows the "Today" state.
+    const row = document.querySelector("#milestoneList .milestone");
+    expect(row).not.toBeNull();
+    expect(row.querySelector(".ms-days").textContent).toBe("Today 🎉");
+    expect(row.querySelector(".ms-days").classList).toContain("is-today");
+
+    row.querySelector(".ms-del").click();
+    await flush();
+    expect(document.querySelectorAll("#milestoneList .milestone").length).toBe(0);
+    expect(store.milestones).toEqual([]);
   });
 
   test("an out-of-range week number is clamped to the year's max", async () => {

--- a/tests/settings.test.js
+++ b/tests/settings.test.js
@@ -33,6 +33,7 @@ describe("SETTINGS_DEFAULTS", () => {
       weekSystem: "iso",
       firstDayOfWeek: 1,
       iconMode: "icon",
+      milestones: [],
     });
   });
 });

--- a/tests/weekUtils.test.js
+++ b/tests/weekUtils.test.js
@@ -10,6 +10,7 @@ const {
   sameYMD,
   daysLeftInWeek,
   daysLeftInYear,
+  daysUntil,
   yearFromDateValue,
   yearProgress,
   getWeekStart,
@@ -75,6 +76,24 @@ describe("daysLeftInYear", () => {
   });
   test("196 days left on Jun 18 2026", () => {
     expect(daysLeftInYear(new Date(2026, 5, 18))).toBe(196);
+  });
+});
+
+describe("daysUntil", () => {
+  test("0 on the same day, ignoring time of day", () => {
+    expect(daysUntil(new Date(2026, 6, 2, 23, 59), new Date(2026, 6, 2, 0, 1))).toBe(0);
+  });
+  test("positive for future dates, across month and year boundaries", () => {
+    expect(daysUntil(new Date(2026, 6, 12), new Date(2026, 6, 2))).toBe(10);
+    expect(daysUntil(new Date(2026, 7, 1), new Date(2026, 6, 31))).toBe(1);
+    expect(daysUntil(new Date(2027, 0, 1), new Date(2026, 11, 31))).toBe(1);
+  });
+  test("negative for past dates", () => {
+    expect(daysUntil(new Date(2026, 6, 1), new Date(2026, 6, 4))).toBe(-3);
+  });
+  test("unaffected by DST transitions (whole-day rounding)", () => {
+    // US DST starts Mar 8 2026 — the 23-hour day must still count as 1.
+    expect(daysUntil(new Date(2026, 2, 9), new Date(2026, 2, 7))).toBe(2);
   });
 });
 

--- a/ui.js
+++ b/ui.js
@@ -41,4 +41,8 @@ export function applyI18n(root) {
       el.setAttribute("aria-label", msg);
     }
   });
+  root.querySelectorAll("[data-i18n-placeholder]").forEach((el) => {
+    const msg = chrome.i18n.getMessage(el.getAttribute("data-i18n-placeholder"));
+    if (msg) el.placeholder = msg;
+  });
 }

--- a/week.js
+++ b/week.js
@@ -142,6 +142,12 @@ export function daysLeftInYear(date) {
   return Math.max(0, Math.round((stripTime(endOfYear) - stripTime(date)) / 86400000));
 }
 
+// Whole days from `from` to `target` (0 = same day, negative = target is past).
+// Drives the milestone countdowns in the popup.
+export function daysUntil(target, from = new Date()) {
+  return Math.round((stripTime(target) - stripTime(from)) / 86400000);
+}
+
 // The 4-digit year from a "YYYY-MM-DD" input value, or `fallbackYear` if empty.
 export function yearFromDateValue(value, fallbackYear) {
   const year = value ? parseInt(String(value).slice(0, 4), 10) : NaN;


### PR DESCRIPTION
## What changed

UX review + rearrangement of the popup so every piece of information sits next to its context, plus a new user-requested Milestones feature.

### Regrouped stats
- **"N days left in week"** now sits directly under the hero week number (was an orphaned footer chip).
- **"N days left in year"** joins the "% through year" caption under the year strip.

### Copy buttons live next to what they copy
- Small inline copy icons beside the week number and beside the date in the hero; the old footer button row is removed.

### Compact single-row controls
- Date + Week inputs, a round **↺ Today** icon button, and the icon color as a **round swatch** (native boxy color well restyled). Labels move to tooltips; the popup is ~200px shorter.

### New: Milestones
- `+` opens an inline name + date form; each milestone shows its date and a live countdown — "44 days left", "Today 🎉", or "3 days ago".
- Sorted soonest-first, deleted via ×, persisted in `chrome.storage.sync` through the canonical `settings.js`.

### Under the hood
- `week.js`: new pure `daysUntil()` helper.
- `settings.js`: `milestones: []` added to `SETTINGS_DEFAULTS`.
- `ui.js`: `applyI18n` now handles `data-i18n-placeholder`.
- `_locales/en`: new milestone strings.

## Testing
- `npm run validate` green: 10 suites, **222 tests** passing, lint clean.
- New tests: `daysUntil` unit tests (incl. a DST-transition case), milestone add/persist/delete DOM integration tests, settings defaults assertion updated.
- Verified end-to-end in Chrome against the built `dist/` bundle (light + dark themes, add → sorted insert → delete flow), zero console errors.

No version bump — no release is triggered by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)