### PR TITLE
Release v1.13 — Popup UX rework + Milestones

### DIFF
--- a/DOCUMENTATION/CHANGELOG.md
+++ b/DOCUMENTATION/CHANGELOG.md
@@ -3,6 +3,23 @@
 All notable changes to the Week Number extension. The release pipeline gate
 expects a `## v<version>` heading for the version being released.
 
+## v1.13 — Popup UX rework + Milestones (2026-07-02)
+
+- **Regrouped stats:** "N days left in week" now sits under the hero week
+  number; "N days left in year" joins the "% through year" caption under the
+  year strip — each stat next to its context.
+- **Inline copy buttons:** small copy icons beside the week number and the
+  date in the hero (the footer button row is gone).
+- **Compact controls:** Date + Week inputs, a round ↺ Today icon button, and
+  the icon color as a round swatch, all on a single row — the popup is
+  noticeably shorter.
+- **New — Milestones:** add a name + date and see a live countdown
+  ("44 days left" / "Today 🎉" / "3 days ago"). Sorted soonest-first,
+  removable with ×, synced across devices via `chrome.storage.sync`.
+- Under the hood: pure `daysUntil()` in `week.js`, `milestones` in
+  `SETTINGS_DEFAULTS`, `data-i18n-placeholder` support in `applyI18n`, new
+  locale strings, and new unit + DOM integration tests (222 total).
+
 ## v1.12 — Footer UX polish (2026-06-18)
 
 - **Packaging fix:** strip Vite's internal `.vite/manifest.json` (and source maps)

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "__MSG_extName__",
   "default_locale": "en",
-  "version": "1.12",
+  "version": "1.13",
   "icons": {
     "16": "icons/icon48.png",
     "48": "icons/icon48.png",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "currentweek",
-  "version": "1.12",
+  "version": "1.13",
   "description": "Manifest V3 browser extension that shows the current ISO 8601 week number, day, and date.",
   "main": "background.js",
   "type": "commonjs",


### PR DESCRIPTION
Bumps `manifest.json` and `package.json` to **1.13** and adds the changelog entry for the popup UX rework + Milestones feature merged in #6.

**Merging this PR publishes v1.13 to the Chrome Web Store and Edge Add-ons** (the version bump on `main` is the publish signal; each store publishes only if its secrets are configured).

Pre-flight done locally:
- `npm run validate` — versions match, lint clean, 222 tests passing
- `./build.sh chrome edge` — both ZIPs built, `manifest.json` at root, exactly one manifest per ZIP

🤖 Generated with [Claude Code](https://claude.com/claude-code)