### PR TITLE
Release workflow: log Chrome token scope (401 diagnosis)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -213,6 +213,9 @@ jobs:
           fi
           echo "::add-mask::$TOKEN"
           echo "token=$TOKEN" >> "$GITHUB_OUTPUT"
+          # Diagnose (safe): print the token's scope/expiry/audience — never the token.
+          INFO=$(curl -s "https://oauth2.googleapis.com/tokeninfo?access_token=$TOKEN" || true)
+          echo "$INFO" | node -p "const i=JSON.parse(require('fs').readFileSync(0,'utf8')); \"tokeninfo: scope=\" + i.scope + \" expires_in=\" + i.expires_in + \" aud=\" + i.aud + \" error=\" + i.error_description" 2>/dev/null || echo "tokeninfo lookup failed"
 
       - name: Upload package to Chrome Web Store
         env:


### PR DESCRIPTION
Chrome upload fails 401 UNAUTHENTICATED while the refresh-token exchange succeeds. Log the minted access token's scope/expiry/audience via Google's tokeninfo endpoint (token itself is never printed) to confirm whether the `chromewebstore` scope is missing. No version change — no publish on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)