### PR TITLE
Release workflow: fix empty-token guard (Bearer undefined → 401)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -205,7 +205,10 @@ jobs:
             -d "client_secret=$CLIENT_SECRET" \
             -d "refresh_token=$REFRESH_TOKEN" \
             -d "grant_type=refresh_token")
-          TOKEN=$(echo "$RESPONSE" | node -p "JSON.parse(require('fs').readFileSync(0,'utf8')).access_token" 2>/dev/null || echo "")
+          # `|| ''` inside node: a missing access_token must yield an empty string —
+          # bare node -p prints the literal "undefined", which passes the -z guard
+          # and becomes a bogus Bearer token (observed as 401s on upload).
+          TOKEN=$(echo "$RESPONSE" | node -p "JSON.parse(require('fs').readFileSync(0,'utf8')).access_token || ''" 2>/dev/null || echo "")
           if [ -z "$TOKEN" ]; then
             echo "::error::Failed to obtain Chrome Web Store access token (refresh token expired/revoked?)"
             echo "$RESPONSE" | sed 's/"access_token":"[^"]*"/"access_token":"[REDACTED]"/g'


### PR DESCRIPTION
Root cause of the v1.13 Chrome publish failure: when the refresh-token exchange returns an error (no `access_token`), `node -p` prints the literal string **"undefined"**, which passes the `-z` guard and becomes `Authorization: Bearer undefined` → 401 UNAUTHENTICATED at upload. (Confirmed via tokeninfo: the log masking of "undefined" as `***` gave it away.)

Coerce missing field to `''` so the token step fails immediately and prints the redacted exchange response — which will show the real error (expected: `invalid_grant`, i.e. the refresh token needs re-minting).

No version change — no publish on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)