### PR TITLE
Local Chrome + Edge publish scripts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,18 @@
+# Local store-publishing credentials for scripts/release-chrome.mjs and
+# scripts/release-edge.mjs. Copy to `.env` (gitignored) and fill in.
+# The same values live as GitHub repository secrets for the CI release
+# workflow; both stores' credentials are developer-account-level and are
+# shared with the owner's other extensions.
+
+# ── Chrome Web Store (OAuth) ────────────────────────────────────────────────
+# Item ID is public; defaults to the Week Number listing if unset.
+CHROME_EXTENSION_ID=hjbeeopedbnpahgbkndkemigkcellibm
+CHROME_CLIENT_ID=
+CHROME_CLIENT_SECRET=
+CHROME_REFRESH_TOKEN=
+
+# ── Edge Add-ons (Publish API v1.1, ApiKey auth) ────────────────────────────
+# Product GUID is public; defaults to the Week Number listing if unset.
+EDGE_PRODUCT_ID=deb64eaf-a710-4ef6-9faa-84aac7fc037f
+EDGE_CLIENT_ID=
+EDGE_API_KEY=

--- a/DOCUMENTATION/RELEASE.md
+++ b/DOCUMENTATION/RELEASE.md
@@ -79,6 +79,24 @@ the ZIPs (uploaded as workflow artifacts) but publishes nothing.
 # build/edge/week-number-v<version>-edge.zip   (manifest.json at ZIP root)
 ```
 
+## Local publish (no CI needed)
+
+Ported from the owner's sf-audit-extractor tooling. Copy `.env.example` to
+`.env` (gitignored) and fill in the credentials — both stores' keys are
+developer-account-level and shared with the owner's other extensions.
+
+```bash
+npm run release:chrome:dry   # build + credential check, no upload
+npm run release:edge:dry     # build + credential probe, no upload
+npm run release:chrome       # build + upload + submit for review
+npm run release:edge         # build + upload + poll validation + submit
+npm run release:stores       # both stores
+# scripts accept --upload-only (draft, no review submission) and --no-build
+```
+
+The scripts print every store API error verbatim (no swallowed responses) and
+fail loudly if the OAuth exchange returns no token.
+
 ## Troubleshooting (seen in the wild)
 
 Learned during the v1.13 release (2026-07-02):

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -71,9 +71,26 @@ module.exports = [
     },
   },
   {
+    // Release scripts — ES modules in a Node context; stdout is their purpose.
+    files: ["scripts/**/*.mjs"],
+    languageOptions: {
+      ecmaVersion: 2022,
+      sourceType: "module",
+      globals: {
+        ...nodeGlobals,
+        fetch: "readonly",
+        URLSearchParams: "readonly",
+        setTimeout: "readonly",
+      },
+    },
+    rules: {
+      "no-console": "off",
+    },
+  },
+  {
     // Dev tooling and tests — CommonJS. Their stdout is their purpose. Tests use
     // jsdom DOM globals, so include the browser set too.
-    files: ["scripts/**", "tests/**", "**/*.cjs", "eslint.config.js"],
+    files: ["scripts/**/*.cjs", "scripts/**/*.js", "tests/**", "**/*.cjs", "eslint.config.js"],
     languageOptions: {
       ecmaVersion: 2022,
       sourceType: "commonjs",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,12 @@
     "build": "./build.sh",
     "package:chrome": "./build.sh chrome",
     "package:edge": "./build.sh edge",
-    "prepare": "husky"
+    "prepare": "husky",
+    "release:chrome": "node scripts/release-chrome.mjs",
+    "release:chrome:dry": "node scripts/release-chrome.mjs --dry-run",
+    "release:edge": "node scripts/release-edge.mjs",
+    "release:edge:dry": "node scripts/release-edge.mjs --dry-run",
+    "release:stores": "node scripts/release-chrome.mjs && node scripts/release-edge.mjs"
   },
   "keywords": [
     "chrome-extension",

--- a/scripts/release-chrome.mjs
+++ b/scripts/release-chrome.mjs
@@ -1,0 +1,161 @@
+#!/usr/bin/env node
+/**
+ * release-chrome.mjs — upload + publish the Week Number extension to the
+ * Chrome Web Store via the official API (v1.1). Ported from the owner's
+ * sf-audit-extractor release tooling.
+ *
+ * Usage:
+ *   npm run release:chrome        # build + upload + publish (submit for review)
+ *   npm run release:chrome:dry    # build + credential check only (no upload)
+ *   node scripts/release-chrome.mjs [--dry-run] [--upload-only] [--no-build]
+ *
+ * Env vars (root .env is loaded; it is gitignored — never commit secrets):
+ *   CHROME_EXTENSION_ID   (defaults to the Week Number item ID)
+ *   CHROME_CLIENT_ID, CHROME_CLIENT_SECRET, CHROME_REFRESH_TOKEN
+ *
+ * Known store-side gate: publish fails with "Publish condition not met …
+ * privacy information" until the item's Privacy practices tab has been filled
+ * once, by hand, in the Developer Dashboard (no API exists for it).
+ */
+
+import { execSync } from "child_process";
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+// ── .env loader (no dependency; real env always wins over .env) ────────────
+function loadDotEnv() {
+  const envPath = path.join(ROOT, ".env");
+  if (!fs.existsSync(envPath)) return;
+  for (const raw of fs.readFileSync(envPath, "utf8").split("\n")) {
+    const line = raw.trim();
+    if (!line || line.startsWith("#")) continue;
+    const eq = line.indexOf("=");
+    if (eq < 0) continue;
+    const key = line.slice(0, eq).trim();
+    let val = line.slice(eq + 1).trim();
+    if ((val.startsWith('"') && val.endsWith('"')) || (val.startsWith("'") && val.endsWith("'"))) {
+      val = val.slice(1, -1);
+    }
+    if (!(key in process.env)) process.env[key] = val;
+  }
+}
+loadDotEnv();
+
+const args = process.argv.slice(2);
+const DRY_RUN = args.includes("--dry-run") || args.includes("--dry");
+const UPLOAD_ONLY = args.includes("--upload-only");
+const NO_BUILD = args.includes("--no-build");
+
+const log = (m) => console.log(`[release-chrome] ${m}`);
+const fail = (m) => {
+  console.error(`[release-chrome] ERR ${m}`);
+  process.exit(1);
+};
+
+const EXTENSION_ID = process.env.CHROME_EXTENSION_ID || "hjbeeopedbnpahgbkndkemigkcellibm";
+const CLIENT_ID = process.env.CHROME_CLIENT_ID;
+const CLIENT_SECRET = process.env.CHROME_CLIENT_SECRET;
+const REFRESH_TOKEN = process.env.CHROME_REFRESH_TOKEN;
+
+const missing = [];
+if (!CLIENT_ID) missing.push("CHROME_CLIENT_ID");
+if (!CLIENT_SECRET) missing.push("CHROME_CLIENT_SECRET");
+if (!REFRESH_TOKEN) missing.push("CHROME_REFRESH_TOKEN");
+if (missing.length) fail(`Missing env vars: ${missing.join(", ")} (see .env.example)`);
+log("Credentials present (values not printed).");
+
+// ── Build + locate ZIP ──────────────────────────────────────────────────────
+if (!NO_BUILD) {
+  log("Building (./build.sh chrome) ...");
+  execSync("./build.sh chrome", { cwd: ROOT, stdio: "inherit" });
+}
+const version = JSON.parse(fs.readFileSync(path.join(ROOT, "manifest.json"), "utf8")).version;
+const zipPath = path.join(ROOT, "build", "chrome", `week-number-v${version}-chrome.zip`);
+if (!fs.existsSync(zipPath)) fail(`ZIP not found: ${zipPath}`);
+log(`Version ${version} — ${zipPath}`);
+
+// ── OAuth token (missing access_token must fail loudly, never "undefined") ──
+async function accessToken() {
+  const res = await fetch("https://oauth2.googleapis.com/token", {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      client_id: CLIENT_ID,
+      client_secret: CLIENT_SECRET,
+      refresh_token: REFRESH_TOKEN,
+      grant_type: "refresh_token",
+    }),
+  });
+  const body = await res.json();
+  if (!body.access_token) {
+    fail(
+      `Token exchange failed (${body.error || res.status}): ${body.error_description || "no access_token"} — ` +
+        `if invalid_grant, re-mint CHROME_REFRESH_TOKEN (see DOCUMENTATION/RELEASE.md)`
+    );
+  }
+  return body.access_token;
+}
+
+async function main() {
+  const token = await accessToken();
+  log("Access token minted OK.");
+  if (DRY_RUN) {
+    log("Dry run — stopping before upload. Everything checks out.");
+    return;
+  }
+
+  // ── Upload ────────────────────────────────────────────────────────────────
+  log(`Uploading to item ${EXTENSION_ID} ...`);
+  const up = await fetch(
+    `https://www.googleapis.com/upload/chromewebstore/v1.1/items/${EXTENSION_ID}`,
+    {
+      method: "PUT",
+      headers: { Authorization: `Bearer ${token}`, "x-goog-api-version": "2" },
+      body: fs.readFileSync(zipPath),
+    }
+  );
+  const upBody = await up.json();
+  if (!up.ok || !["SUCCESS", "IN_PROGRESS"].includes(upBody.uploadState)) {
+    fail(`Upload failed (HTTP ${up.status}): ${JSON.stringify(upBody)}`);
+  }
+  log(`Upload OK (uploadState=${upBody.uploadState}).`);
+
+  if (UPLOAD_ONLY) {
+    log("Upload-only mode — draft saved, not submitted for review.");
+    return;
+  }
+
+  // ── Publish (submit for review) ──────────────────────────────────────────
+  log("Publishing (submit for review) ...");
+  const pub = await fetch(
+    `https://www.googleapis.com/chromewebstore/v1.1/items/${EXTENSION_ID}/publish`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "x-goog-api-version": "2",
+        "Content-Length": "0",
+      },
+    }
+  );
+  const pubBody = await pub.json();
+  if (!pub.ok) {
+    const msg = pubBody?.error?.message || JSON.stringify(pubBody);
+    if (/privacy information/i.test(msg)) {
+      fail(
+        `Publish blocked by the one-time Privacy practices form (no API for it).\n` +
+          `  Fill it by hand: https://chrome.google.com/webstore/devconsole → item → Privacy practices tab,\n` +
+          `  then re-run: npm run release:chrome -- --no-build\n  Store said: ${msg}`
+      );
+    }
+    fail(`Publish failed (HTTP ${pub.status}): ${msg}`);
+  }
+  log(
+    `Chrome Web Store: v${version} submitted for review (status=${JSON.stringify(pubBody.status)}).`
+  );
+}
+
+main().catch((e) => fail(e.stack || String(e)));

--- a/scripts/release-edge.mjs
+++ b/scripts/release-edge.mjs
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+/**
+ * release-edge.mjs — upload + publish the Week Number extension to Edge
+ * Add-ons via the Update REST API v1.1 (ApiKey auth; the Azure AD v1 flow
+ * was retired 2024-12-31). Mirrors the GitHub Actions release job so a
+ * release can also be cut locally.
+ *
+ * Usage:
+ *   npm run release:edge          # build + upload + poll + publish
+ *   npm run release:edge:dry      # build + credential probe only (no upload)
+ *   node scripts/release-edge.mjs [--dry-run] [--upload-only] [--no-build]
+ *
+ * Env vars (root .env is loaded; it is gitignored — never commit secrets):
+ *   EDGE_PRODUCT_ID   (defaults to the Week Number product GUID)
+ *   EDGE_CLIENT_ID  or WEEK_EDGE_CLIENT_ID
+ *   EDGE_API_KEY    or WEEK_EDGE_API_KEY
+ */
+
+import { execSync } from "child_process";
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const API = "https://api.addons.microsoftedge.microsoft.com";
+
+// ── .env loader (no dependency; real env always wins over .env) ────────────
+function loadDotEnv() {
+  const envPath = path.join(ROOT, ".env");
+  if (!fs.existsSync(envPath)) return;
+  for (const raw of fs.readFileSync(envPath, "utf8").split("\n")) {
+    const line = raw.trim();
+    if (!line || line.startsWith("#")) continue;
+    const eq = line.indexOf("=");
+    if (eq < 0) continue;
+    const key = line.slice(0, eq).trim();
+    let val = line.slice(eq + 1).trim();
+    if ((val.startsWith('"') && val.endsWith('"')) || (val.startsWith("'") && val.endsWith("'"))) {
+      val = val.slice(1, -1);
+    }
+    if (!(key in process.env)) process.env[key] = val;
+  }
+}
+loadDotEnv();
+
+const args = process.argv.slice(2);
+const DRY_RUN = args.includes("--dry-run") || args.includes("--dry");
+const UPLOAD_ONLY = args.includes("--upload-only");
+const NO_BUILD = args.includes("--no-build");
+
+const log = (m) => console.log(`[release-edge] ${m}`);
+const fail = (m) => {
+  console.error(`[release-edge] ERR ${m}`);
+  process.exit(1);
+};
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const PRODUCT_ID = process.env.EDGE_PRODUCT_ID || "deb64eaf-a710-4ef6-9faa-84aac7fc037f";
+const CLIENT_ID = process.env.EDGE_CLIENT_ID || process.env.WEEK_EDGE_CLIENT_ID;
+const API_KEY = process.env.EDGE_API_KEY || process.env.WEEK_EDGE_API_KEY;
+
+const missing = [];
+if (!CLIENT_ID) missing.push("EDGE_CLIENT_ID (or WEEK_EDGE_CLIENT_ID)");
+if (!API_KEY) missing.push("EDGE_API_KEY (or WEEK_EDGE_API_KEY)");
+if (missing.length) fail(`Missing env vars: ${missing.join(", ")} (see .env.example)`);
+log("Credentials present (values not printed).");
+
+const authHeaders = { Authorization: `ApiKey ${API_KEY}`, "X-ClientID": CLIENT_ID };
+
+// ── Build + locate ZIP ──────────────────────────────────────────────────────
+if (!NO_BUILD) {
+  log("Building (./build.sh edge) ...");
+  execSync("./build.sh edge", { cwd: ROOT, stdio: "inherit" });
+}
+const version = JSON.parse(fs.readFileSync(path.join(ROOT, "manifest.json"), "utf8")).version;
+const zipPath = path.join(ROOT, "build", "edge", `week-number-v${version}-edge.zip`);
+if (!fs.existsSync(zipPath)) fail(`ZIP not found: ${zipPath}`);
+log(`Version ${version} — ${zipPath}`);
+
+async function main() {
+  if (DRY_RUN) {
+    // Auth probe without side effects: a bogus operation ID returns 404 with
+    // valid credentials and 401/403 with bad ones.
+    const probe = await fetch(
+      `${API}/v1/products/${PRODUCT_ID}/submissions/draft/package/operations/00000000-0000-0000-0000-000000000000`,
+      { headers: authHeaders }
+    );
+    if (probe.status === 401 || probe.status === 403) {
+      fail(`Credential probe failed (HTTP ${probe.status}) — check EDGE_CLIENT_ID / EDGE_API_KEY`);
+    }
+    log(`Dry run — credentials accepted (probe HTTP ${probe.status}). Stopping before upload.`);
+    return;
+  }
+
+  // ── Upload draft package ──────────────────────────────────────────────────
+  log(`Uploading to product ${PRODUCT_ID} ...`);
+  const up = await fetch(`${API}/v1/products/${PRODUCT_ID}/submissions/draft/package`, {
+    method: "POST",
+    headers: { ...authHeaders, "Content-Type": "application/zip" },
+    body: fs.readFileSync(zipPath),
+  });
+  if (up.status !== 202) fail(`Upload failed (HTTP ${up.status}): ${await up.text()}`);
+  const location = up.headers.get("location") || "";
+  const opId = location.replace(/\?.*$/, "").replace(/\/+$/, "").split("/").pop();
+  if (!opId) fail("Could not parse operation ID from Location header");
+  log(`Upload accepted — operation ${opId}. Polling validation ...`);
+
+  // ── Poll package validation (up to ~3 min) ───────────────────────────────
+  let validated = false;
+  for (let i = 1; i <= 18; i++) {
+    await sleep(10000);
+    const res = await fetch(
+      `${API}/v1/products/${PRODUCT_ID}/submissions/draft/package/operations/${opId}`,
+      { headers: authHeaders }
+    );
+    const body = await res.json().catch(() => ({}));
+    log(`  Attempt ${i}/18: status = ${body.status || "Unknown"}`);
+    if (body.status === "Succeeded") {
+      validated = true;
+      break;
+    }
+    if (body.status === "Failed") fail(`Package validation failed: ${JSON.stringify(body)}`);
+  }
+  if (!validated) fail("Timed out waiting for package validation");
+  log("Package validated.");
+
+  if (UPLOAD_ONLY) {
+    log("Upload-only mode — draft saved, not submitted for review.");
+    return;
+  }
+
+  // ── Publish submission ────────────────────────────────────────────────────
+  log("Publishing (submit for review) ...");
+  const pub = await fetch(`${API}/v1/products/${PRODUCT_ID}/submissions`, {
+    method: "POST",
+    headers: { ...authHeaders, "Content-Type": "application/json" },
+    body: JSON.stringify({ notes: `Automated release v${version}` }),
+  });
+  if (pub.status !== 202) fail(`Publish failed (HTTP ${pub.status}): ${await pub.text()}`);
+  log(`Edge Add-ons: v${version} submitted for review.`);
+}
+
+main().catch((e) => fail(e.stack || String(e)));


### PR DESCRIPTION
Ports the sf-audit-extractor release tooling to this repo so releases can be cut locally without CI: `npm run release:chrome` / `release:edge` / `release:stores` (+`:dry` variants, `--upload-only`, `--no-build`). Credentials load from the gitignored `.env` (documented in `.env.example`). Both dry-runs verified against the live store APIs; the Chrome script did a real upload (uploadState=SUCCESS). No version change — no publish on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)