### PR TITLE
Add hosted privacy policy page for store listings

### DIFF
--- a/docs/privacy.html
+++ b/docs/privacy.html
@@ -1,0 +1,103 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Privacy Policy — Week Number</title>
+    <style>
+      body {
+        font-family:
+          -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+        max-width: 720px;
+        margin: 0 auto;
+        padding: 2rem 1.25rem 4rem;
+        line-height: 1.6;
+        color: #1f2328;
+      }
+      h1 {
+        font-size: 1.6rem;
+      }
+      h2 {
+        font-size: 1.15rem;
+        margin-top: 2rem;
+      }
+      code {
+        background: #f0f1f3;
+        padding: 0.1em 0.35em;
+        border-radius: 4px;
+      }
+      footer {
+        margin-top: 3rem;
+        font-size: 0.85rem;
+        color: #57606a;
+      }
+      @media (prefers-color-scheme: dark) {
+        body {
+          background: #0d1117;
+          color: #e6edf3;
+        }
+        code {
+          background: #21262d;
+        }
+        footer {
+          color: #8b949e;
+        }
+        a {
+          color: #58a6ff;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Privacy Policy — Week Number browser extension</h1>
+    <p><strong>Effective date:</strong> 3 July 2026</p>
+    <p>
+      Week Number is a browser extension for Google Chrome and Microsoft Edge that displays the
+      current ISO 8601 (or US) week number, day, and date. This policy describes what data the
+      extension handles.
+    </p>
+
+    <h2>Data we collect</h2>
+    <p>
+      <strong>None.</strong> Week Number does not collect, transmit, sell, or share any personal
+      data, browsing history, or usage analytics. The extension makes no network requests and
+      contains no tracking, advertising, or third-party code.
+    </p>
+
+    <h2>Data stored on your device</h2>
+    <p>
+      The extension saves only your display preferences — theme, week-numbering system (ISO or US),
+      first day of the week, and toolbar display options — using the browser's
+      <code>chrome.storage.sync</code> API. This data stays inside your browser profile. If you are
+      signed in to your browser and have sync enabled, the browser vendor (Google or Microsoft) may
+      sync these preferences across your devices under their own privacy terms; the developer of
+      Week Number never receives or has access to them.
+    </p>
+
+    <h2>Permissions</h2>
+    <ul>
+      <li><code>storage</code> — save your display preferences, as described above.</li>
+      <li><code>alarms</code> — schedule the daily refresh of the toolbar icon at midnight.</li>
+    </ul>
+    <p>The extension requests no access to websites, tabs, or browsing activity.</p>
+
+    <h2>Changes to this policy</h2>
+    <p>
+      Any future change to this policy will be published on this page with an updated effective
+      date.
+    </p>
+
+    <h2>Contact</h2>
+    <p>
+      Questions about this policy:
+      <a href="mailto:behera.manas98@gmail.com">behera.manas98@gmail.com</a>
+    </p>
+
+    <footer>
+      Week Number is open source:
+      <a href="https://github.com/manaskumarbehera/CurrentWeek"
+        >github.com/manaskumarbehera/CurrentWeek</a
+      >
+    </footer>
+  </body>
+</html>


### PR DESCRIPTION
Chrome Web Store rejected v1.13 today (violation reference **Purple Nickel**, User data privacy): *"Privacy policy link does not lead to a valid privacy policy."*

This adds `docs/privacy.html` — a standalone, truthful privacy policy (no data collected; settings stored via `chrome.storage.sync`; permissions `storage` + `alarms` explained). It will be served via GitHub Pages (source: `main`/`docs`) at:

**https://manaskumarbehera.github.io/CurrentWeek/privacy.html**

That URL then goes into the Chrome Web Store Privacy tab (and the Edge listing) as the privacy policy link, and the rejected item gets resubmitted.

No version bump — this does not trigger a store release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)