### PR TITLE
Pages: redirect site root to privacy policy

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="refresh" content="0; url=./privacy.html" />
+    <title>Week Number</title>
+    <link rel="canonical" href="https://manaskumarbehera.github.io/CurrentWeek/privacy.html" />
+  </head>
+  <body>
+    <p>Redirecting to the <a href="./privacy.html">Week Number privacy policy</a>…</p>
+  </body>
+</html>


### PR DESCRIPTION
Week Number was rejected a second time with the same 'Purple Nickel' violation even though https://manaskumarbehera.github.io/CurrentWeek/privacy.html serves the policy (HTTP 200). The site root 404'd; this adds a root index.html that redirects to the policy so every path a reviewer might try lands on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)